### PR TITLE
fix: mermaid theme mismatch when user default theme is light

### DIFF
--- a/containers/Post/PostDetail/CustomMermaid.tsx
+++ b/containers/Post/PostDetail/CustomMermaid.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useEffect } from 'react'
 import { useThemeMode } from '../../../hooks/useThemeMode'
 import mermaid, { Config } from 'mermaid'
 
@@ -14,11 +14,11 @@ export function CustomMermaid({ children, isMermaidLoaded }: CustomMermaydType) 
     setMermaid(theme === 'dark' ? 'dark' : 'default')
   }
 
-  return (
-    <div className="mermaid" ref={withMemoized}>
-      {children}
-    </div>
-  )
+  useEffect(() => {
+    withMemoized()
+  }, [theme])
+
+  return <div className="mermaid">{children}</div>
 }
 
 /**


### PR DESCRIPTION
## Root cause
- Server side default theme is dark, as set in `useThemeMode.ts`, meaning that
- Client side initially set theme as dark and then change to light theme, and the mermaid `contentLoad()` is not triggered since we have memoize to prevent happening

## Solution
- change from `ref callback` → `useEffect`
- theme as the dependency in useEffect